### PR TITLE
ECONOMY-4 – improve various DataWrapper call + response handling logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ We have 3 POST api endpoints
 - deployedURL/api/datawrapper-proxy
     - This route is a POST request to allow us to create datawrapper charts in the client side, by running a proxy server route
     - It takes in {csv, indicator, location, chartType} in the body
-    - Response 200 json, with the resolved chartId for the published chart
+    - Response 200 json, with the resolved chartId and chartUrl for the published chart
 - deployedURL/api/location-topic-form
     - This route is a POST request to allow us to redirect to different pages of the site after submitting a form
     - It takes in location and topic in the body
@@ -127,11 +127,7 @@ We used Tailwind CSS for styling components. While some components are reused ac
 
 ### Form
 
-As it stands, the only way to update content, style and functionality on the site is through altering the code. In some cases (especially content), this will be easy without a knowledge of code. 
-
-### Extensive error handling
-
-There is currently not comprehensive error handling, meaning that sometimes the user will see untailored error messages. There are known bugs on the choropleth (data is sometimes not updated in time to appear on the page). Extensive use of the site may result in a 500 error message on all pages of the site, since the free plan of the remote database used for the site limits the number of database requests. 
+As it stands, the only way to update content, style and functionality on the site is through altering the code. In some cases (especially content), this will be easy without a knowledge of code.
 
 ### Further finessing of Datawrapper
 

--- a/components/hooks/useChoropleth.jsx
+++ b/components/hooks/useChoropleth.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 
 export default function useDatawrapper() {
-  const [chartId, setChartId] = useState(null);
+  const [chartUrl, setChartUrl] = useState(null);
   const [loading, setLoading] = useState(null);
   const [dataset, setDataset] = useState(null);
   const [indicator, setIndicator] = useState(null);
@@ -20,6 +20,10 @@ export default function useDatawrapper() {
 
   // Send the datawrapper-proxy the details needed to send to datawrapper
   useEffect(() => {
+    if (!csv || !indicator) {
+      return
+    }
+
     setLoading(true);
     fetch("/api/datawrapper-proxy", {
       method: "POST",
@@ -32,10 +36,10 @@ export default function useDatawrapper() {
     })
       .then((resolve) => resolve.json())
       .then((resolve) => {
-        setChartId(resolve.chartId);
+        setChartUrl(resolve.chartUrl);
         setLoading(false);
       });
   }, [csv, indicator]);
 
-  return [chartId, loading, setDataset, setIndicator];
+  return [chartUrl, loading, setDataset, setIndicator];
 }

--- a/components/hooks/useDatawrapper.jsx
+++ b/components/hooks/useDatawrapper.jsx
@@ -1,11 +1,15 @@
 import { useState, useEffect } from "react";
 
 export default function useDatawrapper(csv, indicator, location, chartType) {
-  const [chartId, setChartId] = useState(null);
+  const [chartUrl, setChartUrl] = useState(null);
   const [loading, setLoading] = useState(false);
 
   // Sends the details to datawrapper-proxy to then send to datawrapper
   useEffect(() => {
+    if (!csv || !indicator) {
+      return
+    }
+
     setLoading(true);
     fetch("/api/datawrapper-proxy", {
       method: "POST",
@@ -18,10 +22,10 @@ export default function useDatawrapper(csv, indicator, location, chartType) {
     })
       .then((resolve) => resolve.json())
       .then((resolve) => {
-        setChartId(resolve.chartId);
+        setChartUrl(resolve.chartUrl);
         setLoading(false);
       });
   }, [csv, indicator, location, chartType]);
 
-  return [chartId, loading];
+  return [chartUrl, loading];
 }

--- a/pages/[location]/indicator/[indicator].js
+++ b/pages/[location]/indicator/[indicator].js
@@ -58,13 +58,13 @@ export default function Indicator({
   chartCsv,
   tableCsv,
 }) {
-  const [lineChartId, lineChartLoading] = useDatawrapper(
+  const [lineChartUrl, lineChartLoading] = useDatawrapper(
     chartCsv,
     indicator,
     location,
     "d3-lines"
   );
-  const [tableId, tableLoading] = useDatawrapper(
+  const [tableUrl, tableLoading] = useDatawrapper(
     tableCsv,
     indicator,
     location,
@@ -108,14 +108,16 @@ export default function Indicator({
           {lineChartLoading === true ? (
             <Loading />
           ) : (
-            <iframe
-              title={`A chart showing the change in ${indicator} in ${location}`}
-              id="datawrapper-chart-0jKkG"
-              src={`https://datawrapper.dwcdn.net/${lineChartId}/1/`}
-              className="w-full min-w-full h-full"
-              scrolling="no"
-              frameBorder="0"
-            ></iframe>
+            lineChartUrl ? (
+              <iframe
+                title={`A chart showing the change in ${indicator} in ${location}`}
+                id="datawrapper-chart-0jKkG"
+                src={lineChartUrl}
+                className="w-full min-w-full h-full"
+                scrolling="no"
+                frameBorder="0"
+              ></iframe>
+            ) : undefined
           )}
         </div>
       </div>
@@ -124,15 +126,17 @@ export default function Indicator({
         {tableLoading === true ? (
           <Loading />
         ) : (
-          <iframe
-            style={{ height: tableHeight }}
-            title={`A table for ${indicator} in ${location}`}
-            id="datawrapper-chart-0jKkG"
-            src={`https://datawrapper.dwcdn.net/${tableId}/1/`}
-            className="w-full min-w-full h-full"
-            scrolling="no"
-            frameBorder="0"
-          ></iframe>
+          tableUrl ? (
+            <iframe
+              style={{ height: tableHeight }}
+              title={`A table for ${indicator} in ${location}`}
+              id="datawrapper-chart-0jKkG"
+              src={tableUrl}
+              className="w-full min-w-full h-full"
+              scrolling="no"
+              frameBorder="0"
+            ></iframe>
+          ) : undefined
         )}
       </div>
     </main>

--- a/pages/api/datawrapper-proxy.js
+++ b/pages/api/datawrapper-proxy.js
@@ -5,7 +5,11 @@ import dataVisualiser from "../../utils/dataVisualiser";
 export default async function handler(req, res) {
   const { csv, indicator, location, chartType } = JSON.parse(req.body);
 
-  const chartId = await dataVisualiser(csv, indicator, location, chartType);
+  const chartIdAndUrl = await dataVisualiser(csv, indicator, location, chartType);
 
-  res.status(200).json({ chartId });
+  if (chartIdAndUrl === undefined) {
+    res.status(500).json({ error: 'DataWrapper calls failed'});
+  }
+
+  res.status(200).json(chartIdAndUrl);
 }

--- a/pages/map.js
+++ b/pages/map.js
@@ -52,7 +52,7 @@ export default function Map({
   const [indicatorOptions, setIndicatorOptions] = useState(
     selectOptions(filteredAllIndicators)
   );
-  const [mapId, mapLoading, setMapData, setMapIndicator] = useChoropleth();
+  const [mapUrl, mapLoading, setMapData, setMapIndicator] = useChoropleth();
 
   //filters viewable indicators on the basis of chosen topic
   useEffect(() => {
@@ -123,13 +123,15 @@ export default function Map({
         {mapLoading ? (
           <Loading />
         ) : (
+          mapUrl ? (
           <iframe
             title={`choropleth showing ${indicator?.value} in London`}
-            src={`https://datawrapper.dwcdn.net/${mapId}/1/`}
+            src={mapUrl}
             className="w-full min-w-full h-full"
             scrolling="no"
             frameBorder="0"
           ></iframe>
+          ) : undefined
         )}
       </div>
     </>

--- a/utils/dataVisualiser.js
+++ b/utils/dataVisualiser.js
@@ -1,3 +1,12 @@
+import { callDWAndLogErrors } from './dataWrapper';
+
+/**
+ * @typedef {Object} ChartResult
+ * @property {string} chartId
+ * @property {string} chartUrl
+ *
+ * @return {ChartResult | undefined}
+ */
 export default async function dataVisualiser(
   indicatorCsv,
   indicator,
@@ -15,109 +24,85 @@ export default async function dataVisualiser(
   }
 
   //initialises empty chart
-  const postResponse = await fetch("https://api.datawrapper.de/v3/charts", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${process.env.DATAWRAPPER_API_KEY}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({
-      folderId: parseInt(process.env.DATAWRAPPER_FOLDER_ID, 10),
-      organizationId: process.env.DATAWRAPPER_TEAM_ID,
-      title: title,
-      type: chartType,
-      lastEditStep: 3,
-    }),
-  });
+  const postResponse = await callDWAndLogErrors('/charts', 'POST', JSON.stringify({
+    folderId: parseInt(process.env.DATAWRAPPER_FOLDER_ID, 10),
+    organizationId: process.env.DATAWRAPPER_TEAM_ID,
+    title: title,
+    type: chartType,
+    lastEditStep: 3,
+  }));
 
-  if (postResponse.status >= 400) {
-    console.log(`Initial chart creation failed with ${postResponse.status} (${postResponse.statusText})`);
-
+  if (postResponse === undefined) {
     return undefined;
   }
 
   //chartId needed for URL that will ultimately be put into the iframe on the page
-  const postJson = await postResponse.json();
-  const chartId = postJson.id;
+  const chartId = postResponse.id;
+
+  if (indicatorCsv === null) {
+    console.log('Bailing out as we have no data!');
+    return undefined;
+  }
 
   //populates chart with data
-  const putResponse = await fetch(
-    `https://api.datawrapper.de/v3/charts/${chartId}/data`,
-    {
-      method: "PUT",
-      headers: {
-        Authorization: `Bearer ${process.env.DATAWRAPPER_API_KEY}`,
-        "content-type": "text/csv",
-      },
-
-      body: indicatorCsv,
-    }
-  );
+  const putResponse = await callDWAndLogErrors(`/charts/${chartId}/data`, 'PUT', indicatorCsv, true);
 
   //for choropleth, sets basemap and adds tooltip
   if (chartType === "d3-maps-choropleth") {
-    const patchResponse = await fetch(
-      `https://api.datawrapper.de/v3/charts/${chartId}`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${process.env.DATAWRAPPER_API_KEY}`,
-          "content-type": "application/json",
+    const patchResponse = await callDWAndLogErrors(`/charts/${chartId}`, 'PATCH', JSON.stringify({
+      metadata: {
+        axes: {
+          keys: "code",
+          values: "literacy-rate",
         },
-
-        body: JSON.stringify({
-          metadata: {
-            axes: {
-              keys: "code",
-              values: "literacy-rate",
-            },
-            visualize: {
-              basemap: "uk-lads-greater-london",
-              "map-key-attr": "lad15nm",
-            },
-          },
-        }),
-      }
-    );
+        visualize: {
+          basemap: "uk-lads-greater-london",
+          "map-key-attr": "lad15nm",
+        },
+      },
+    }));
 
     // This adds the hover tooltip for the choropleth
-    const addTooltip = await fetch(
-      `https://api.datawrapper.de/v3/charts/${chartId}`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${process.env.DATAWRAPPER_API_KEY}`,
-          "content-type": "application/json",
-        },
-
-        body: JSON.stringify({
-          metadata: {
-            visualize: {
-              tooltip: {
-                body: `Indicator value: {{ indicator }}`,
-                title: "Borough: {{ location }}",
-                fields: {
-                  location: "location",
-                  indicator: indicator,
-                },
-              },
+    const addTooltip = await callDWAndLogErrors(`/charts/${chartId}`, 'PATCH', JSON.stringify({
+      metadata: {
+        visualize: {
+          tooltip: {
+            body: `Indicator value: {{ indicator }}`,
+            title: "Borough: {{ location }}",
+            fields: {
+              location: "location",
+              indicator: indicator,
             },
           },
-        }),
-      }
-    );
+        },
+      },
+    }));
   }
 
   //publishes chart online with chartId in the URL
-  const publishResponse = await fetch(
-    `https://api.datawrapper.de/charts/${chartId}/publish`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${process.env.DATAWRAPPER_API_KEY}`,
-      },
-    }
-  );
+  const publishResponse = await callDWAndLogErrors(`/charts/${chartId}/publish`, 'POST');
 
-  return chartId;
+  if (publishResponse === undefined) {
+    return undefined;
+  }
+
+  const chartUrl = publishResponse.data.publicUrl;
+
+  // /** @param number */
+  // const publishVersion = publishResponse.version;
+
+  // TODO: Awaiting reply from DataWrapper regarding this always 404'ing.
+  // const publishStatusResponse = await callDWAndLogErrors(`/charts/${chartId}/publish/status/${publishVersion}`, 'GET');
+  // console.log('Status?', publishStatusResponse);
+
+  // We *could* potentially use the custom webhooks feature in DataWrapper settings, but this is a lot of
+  // complexity we don't have time for this sprint (e.g. to have the server ping the client with Websockets),
+  // *and* we'd eventually hit limitations with it only having 1 URL (what about Production?). So for now,
+  // to make this less flaky than the first proof of concept we poll every 0.5s for up to 15s using the publish
+  // status endpoint.
+
+  return {
+    chartId,
+    chartUrl,
+  };
 }

--- a/utils/dataWrapper.js
+++ b/utils/dataWrapper.js
@@ -1,0 +1,34 @@
+const BASE_URI = 'https://api.datawrapper.de/v3';
+
+/**
+ * @returns body JSON if applicable; `true` if not (e.g. data PUT); undefined on error.
+ */
+export async function callDWAndLogErrors(endpoint, method, body, isCSV = false) {
+  const response = await fetch(`${BASE_URI}${endpoint}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${process.env.DATAWRAPPER_API_KEY}`,
+      'content-type': isCSV ? 'text/csv' : 'application/json',
+    },
+    body,
+  })
+  .catch(err => {
+    console.log(`Uncaught error calling DataWrapper ${method} ${endpoint}: ${err}`);
+
+    return undefined;
+  });
+
+  if (response.status >= 400) {
+    console.log(`Error HTTP code calling DataWrapper ${method} ${endpoint}: ${response.status} (${response.statusText}). Body: ${JSON.stringify(await response.json())}`);
+
+    return undefined;
+  }
+
+  if (isCSV) {
+    return true; // https://developer.datawrapper.de/reference/putchartsiddata just returns 204 with no data.
+  }
+
+  const data = await response.json();
+
+  return data;
+}


### PR DESCRIPTION
* don't call the internal API with either of the essential data properties blank
* try to render a chart iframe if and only if the URL is set
* return chart URL directly from the API instead of piecing it together manually
* add server-side error logging for issues with all DataWrapper API calls
* reduce boilerplate repeated code for those calls